### PR TITLE
Добавлен эксперимент с ISCSI

### DIFF
--- a/kubernetes-storage/iscsi/pod-iscsi.yaml
+++ b/kubernetes-storage/iscsi/pod-iscsi.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-iscsi-pod
+spec:
+  restartPolicy: Always
+  containers:
+  - name: my-iscsi-pod
+    image: nginx
+    volumeMounts:
+      - name: iscsi-test
+        mountPath: /mnt
+  volumes:
+  - name: iscsi-test
+    iscsi:
+      targetPortal: 192.168.3.84:3260
+      iqn: iqn.2003-01.org.linux-iscsi.ubuntu.x8664:sn.688109fa3d99
+      fsType: ext4
+      lun: 0
+      readOnly: false
+


### PR DESCRIPTION
# Выполнено ДЗ №

 - [*] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
- Подготовлен файл cluster.yaml с необходимой конфигурацией для kind;
- В директории `hw` созданы манифесты для создания объектов StorageClass, pvc и pod;

## Как запустить проект:
- Установить go версии > 1.13 (https://sourabhbajaj.com/mac-setup/Go/README.html)
- Установить kind (https://kind.sigs.k8s.io/docs/user/quick-start/)
- Перейти в директорию `kubernetes-storage/cluster` и создать кластер с помощью kind с кастомным конфигом: `kind create cluster --config cluster.yaml`
- Задать переменную окружения, для использования конфига kind: `export KUBECONFIG="$(kind get kubeconfig-path)"`
- Установить CSI Host Path Driver: 
  - `git clone https://github.com/kubernetes-csi/csi-driver-host-path.git`
  - `./csi-driver-host-path/deploy/kubernetes-1.15/deploy-hostpath.sh`


## Как проверить работоспособность:
- Перейти в директорию `kubernetes-storage/hw` и последовательно выполнить: 
  - `kubectl apply -f 01-sc.yaml`
  - `kubectl apply -f 02-pvc.yaml`
  - `kubectl apply -f 03-pod.yaml`
- Проверить результат. 

iscsi залью попозже

## PR checklist:
 - [ ] Выставлен label с номером домашнего задания