### PR TITLE
ДЗ 6 Операторы

### DIFF
--- a/kubernetes-operators/build/Dockerfile
+++ b/kubernetes-operators/build/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.7
+COPY templates ./templates
+COPY mysql-operator.py ./mysql-operator.py
+RUN pip install kopf kubernetes pyyaml jinja2
+CMD kopf run /mysql-operator.py

--- a/kubernetes-operators/build/mysql-operator.py
+++ b/kubernetes-operators/build/mysql-operator.py
@@ -1,0 +1,135 @@
+import kopf
+import yaml
+import kubernetes
+import time
+from jinja2 import Environment, FileSystemLoader
+
+
+def wait_until_job_end(jobname):
+    api = kubernetes.client.BatchV1Api()
+    job_finished = False
+    jobs = api.list_namespaced_job('default')
+    while (not job_finished) and \
+            any(job.metadata.name == jobname for job in jobs.items):
+        time.sleep(1)
+        jobs = api.list_namespaced_job('default')
+        for job in jobs.items:
+            if job.metadata.name == jobname:
+                print(f"job with { jobname }  found,wait untill end")
+                if job.status.succeeded == 1:
+                    print(f"job with { jobname }  success")
+                    job_finished = True
+
+
+def render_template(filename, vars_dict):
+    env = Environment(loader=FileSystemLoader('./templates'))
+    template = env.get_template(filename)
+    yaml_manifest = template.render(vars_dict)
+    json_manifest = yaml.load(yaml_manifest)
+    return json_manifest
+
+
+def delete_success_jobs(mysql_instance_name):
+    print("start deletion")
+    api = kubernetes.client.BatchV1Api()
+    jobs = api.list_namespaced_job('default')
+    for job in jobs.items:
+        jobname = job.metadata.name
+        if (jobname == f"backup-{mysql_instance_name}-job") or \
+                (jobname == f"restore-{mysql_instance_name}-job"):
+            if job.status.succeeded == 1:
+                api.delete_namespaced_job(jobname,
+                                          'default',
+                                          propagation_policy='Background')
+
+
+@kopf.on.create('otus.homework', 'v1', 'mysqls')
+# Функция, которая будет запускаться при создании объектов тип MySQL:
+def mysql_on_create(body, spec, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image']
+    password = body['spec']['password']
+    database = body['spec']['database']
+    storage_size = body['spec']['storage_size']
+
+    # Генерируем JSON манифесты для деплоя
+    persistent_volume = render_template('mysql-pv.yml.j2',
+                                        {'name': name,
+                                         'storage_size': storage_size})
+    persistent_volume_claim = render_template('mysql-pvc.yml.j2',
+                                              {'name': name,
+                                               'storage_size': storage_size})
+    service = render_template('mysql-service.yml.j2', {'name': name})
+
+    deployment = render_template('mysql-deployment.yml.j2', {
+        'name': name,
+        'image': image,
+        'password': password,
+        'database': database})
+    restore_job = render_template('restore-job.yml.j2', {
+        'name': name,
+        'image': image,
+        'password': password,
+        'database': database})
+
+    # Определяем, что созданные ресурсы являются дочерними к управляемому CustomResource:
+    kopf.append_owner_reference(persistent_volume, owner=body)
+    kopf.append_owner_reference(persistent_volume_claim, owner=body)  # addopt
+    kopf.append_owner_reference(service, owner=body)
+    kopf.append_owner_reference(deployment, owner=body)
+    # ^ Таким образом при удалении CR удалятся все, связанные с ним pv,pvc,svc, deployments
+
+    api = kubernetes.client.CoreV1Api()
+    # Создаем mysql PV:
+    api.create_persistent_volume(persistent_volume)
+    # Создаем mysql PVC:
+    api.create_namespaced_persistent_volume_claim('default', persistent_volume_claim)
+    # Создаем mysql SVC:
+    api.create_namespaced_service('default', service)
+
+    # Создаем mysql Deployment:
+    api = kubernetes.client.AppsV1Api()
+    api.create_namespaced_deployment('default', deployment)
+    # Пытаемся восстановиться из backup
+    try:
+        api = kubernetes.client.BatchV1Api()
+        api.create_namespaced_job('default', restore_job)
+    except kubernetes.client.rest.ApiException:
+        pass
+
+    # Cоздаем PVC  и PV для бэкапов:
+    try:
+        backup_pv = render_template('backup-pv.yml.j2', {'name': name})
+        api = kubernetes.client.CoreV1Api()
+        print(api.create_persistent_volume(backup_pv))
+        api.create_persistent_volume(backup_pv)
+    except kubernetes.client.rest.ApiException:
+        pass
+
+    try:
+        backup_pvc = render_template('backup-pvc.yml.j2', {'name': name})
+        api = kubernetes.client.CoreV1Api()
+        api.create_namespaced_persistent_volume_claim('default', backup_pvc)
+    except kubernetes.client.rest.ApiException:
+        pass
+
+
+@kopf.on.delete('otus.homework', 'v1', 'mysqls')
+def delete_object_make_backup(body, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image']
+    password = body['spec']['password']
+    database = body['spec']['database']
+
+    delete_success_jobs(name)
+
+    # Cоздаем backup job:
+    api = kubernetes.client.BatchV1Api()
+    backup_job = render_template('backup-job.yml.j2', {
+        'name': name,
+        'image': image,
+        'password': password,
+        'database': database})
+    api.create_namespaced_job('default', backup_job)
+    wait_until_job_end(f"backup-{name}-job")
+    return {'message': "mysql and its children resources deleted"}

--- a/kubernetes-operators/build/templates/backup-job.yml.j2
+++ b/kubernetes-operators/build/templates/backup-job.yml.j2
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  name: backup-{{ name }}-job
+  labels:
+    usage: backup-{{ name }}-job
+spec:
+  template:
+    metadata:
+      name: backup-{{ name }}-cronjob
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: backup-{{ name }}
+        image: {{ image }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mysqldump -u root -h {{ name }} -p{{ password }} {{ database }}  > /backup-{{ name }}-pv/{{ name }}-dump.sql"
+        volumeMounts:
+        - name: backup-{{ name }}-pv
+          mountPath: /backup-{{ name }}-pv
+      volumes:
+      - name: backup-{{ name }}-pv
+        persistentVolumeClaim:
+          claimName: backup-{{ name }}-pvc

--- a/kubernetes-operators/build/templates/backup-pv.yml.j2
+++ b/kubernetes-operators/build/templates/backup-pv.yml.j2
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name:  "backup-{{ name }}-pv"
+  labels:
+    pv-usage: "backup-{{ name }}"
+spec:
+  persistentVolumeReclaimPolicy: Retain
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  hostPath:
+    path: /data/pv-backup/
+ 

--- a/kubernetes-operators/build/templates/backup-pvc.yml.j2
+++ b/kubernetes-operators/build/templates/backup-pvc.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "backup-{{ name }}-pvc"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "1Gi"
+  selector:
+    matchLabels:
+      pv-usage: "backup-{{ name }}"

--- a/kubernetes-operators/build/templates/mysql-deployment.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-deployment.yml.j2
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ name }}
+  template:
+    metadata:
+      labels:
+        app: {{ name }}
+    spec:
+      containers:
+      - image: {{ image }}
+        name: {{ name }}
+        args:
+        - "--ignore-db-dir=lost+found"
+        env:
+        - name: MYSQL_ROOT_PASSWORD # так делать не нужно, тут лучше secret
+          value: {{ password }}
+        - name: MYSQL_DATABASE
+          value: {{ database }}
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: {{ name }}-pv
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: {{ name }}-pv
+        persistentVolumeClaim:
+          claimName: {{ name }}-pvc

--- a/kubernetes-operators/build/templates/mysql-pv.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-pv.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ name }}-pv
+  labels:
+    pv-usage: {{ name }}
+spec:
+  persistentVolumeReclaimPolicy: Retain
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: {{ storage_size }}
+  hostPath:
+    path: /data/{{ name }}-pv/

--- a/kubernetes-operators/build/templates/mysql-pvc.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-pvc.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ name }}-pvc"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: {{ storage_size }}
+  selector:
+    matchLabels:
+      pv-usage: {{ name }}

--- a/kubernetes-operators/build/templates/mysql-service.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-service.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ name }}
+spec:
+  ports:
+  - port: 3306
+  selector:
+    app: {{ name }}
+  clusterIP: None

--- a/kubernetes-operators/build/templates/restore-job.yml.j2
+++ b/kubernetes-operators/build/templates/restore-job.yml.j2
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  name: restore-{{ name }}-job
+spec:
+  template:
+    metadata:
+      name: restore-{{ name }}-job
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: backup
+        image: mysql:5.7
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mysql -u root -h {{ name }} -p{{ password }} {{ database }}< /backup-{{ name }}-pv/{{ name }}-dump.sql"
+        volumeMounts:
+        - name: backup-{{ name }}-pv
+          mountPath: /backup-{{ name }}-pv
+      volumes:
+      - name: backup-{{ name }}-pv
+        persistentVolumeClaim:
+          claimName: backup-{{ name }}-pvc

--- a/kubernetes-operators/deploy/ClusterRoleBinding.yml
+++ b/kubernetes-operators/deploy/ClusterRoleBinding.yml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: workshop-operator
+subjects:
+- kind: ServiceAccount
+  name: mysql-operator
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: mysql-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-operators/deploy/cr.yml
+++ b/kubernetes-operators/deploy/cr.yml
@@ -1,0 +1,10 @@
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+  name: mysql-instance
+spec:
+  image: mysql:5.7
+  database: otus-database
+  password: otuspassword # Так делать не нужно, следует использовать secret
+  storage_size: 1Gi
+# usless_data: "useless info"

--- a/kubernetes-operators/deploy/crd.yml
+++ b/kubernetes-operators/deploy/crd.yml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework # имя CRD должно иметь формат plural.group
+spec:
+  scope: Namespaced     # Данный CRD будер работать в рамках namespace
+  group: otus.homework  # Группа, отражается в поле apiVersion CR
+  versions:             # Список версий
+    - name: v1
+      served: true      # Будет ли обслуживаться API-сервером данная версия
+      storage: true     # Фиксирует  версию описания, которая будет сохраняться в etcd
+  names:                # различные форматы имени объекта CR
+    kind: MySQL         # kind CR
+    plural: mysqls      
+    singular: mysql
+    shortNames:
+      - ms
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+          properties:
+            name:
+              type: string
+        spec:
+          type: object
+          properties:
+            image: 
+              type: string
+            database:
+              type: string
+            password:
+              type: string
+            storage_size:
+              type: string
+          required:
+          - image
+          - database
+          - password
+          - storage_size
+      required:
+      - apiVersion
+      - kind
+      - metadata
+      - spec

--- a/kubernetes-operators/deploy/deploy-operator.yml
+++ b/kubernetes-operators/deploy/deploy-operator.yml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mysql-operator
+  template:
+    metadata:
+      labels:
+        name: mysql-operator
+    spec:
+      serviceAccountName: mysql-operator
+      containers:
+        - name: operator
+          # image: "zhenkins/mysql-operator:v0.1"
+          image: "ustinsky/mysql-operator:v0.0.1"
+          imagePullPolicy: "Always"

--- a/kubernetes-operators/deploy/role.yml
+++ b/kubernetes-operators/deploy/role.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: mysql-operator
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/kubernetes-operators/deploy/service-account.yml
+++ b/kubernetes-operators/deploy/service-account.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-operator


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
Домашняя работа 7 (operators)
1. CRD CR Mysql

    1.1 Создадим 
        kubectl apply -f deploy/crd.yml
        kubectl apply -f deploy/cr.yml

    1.2 Взаимодействие с объектами
        kubectl get crd
        kubectl get mysqls.otus.homework
        kubectl describe mysqls.otus.homework mysql-instance


    1.3 Добавим спецификацию полей (добавляется поле validation)
        kubectl delete mysqls.otus.homework mysql-instance
        kubectl apply -f deploy/crd.yaml
        kubectl apply -f deploy/cr.yaml

    1.4 Запустим оператор
        apt install python3-pip
        pip3 install kopf
        PATH="$PATH:/home/lex/.local/bin/"
        pip3 install kubernetes jinja2
        kopf run mysql-operator.py

    1.5 Почему объект создался, хотя мы создали CR, до того, как запустили контроллер?
        Ответ из документации
        https://kopf.readthedocs.io/en/latest/walkthrough/starting/

        Note that the operator has noticed an object created before the operator was even started, 
        and handled it – since it was not handled before.

        Обратите внимание, что оператор заметил объект, созданный еще до того, как оператор был запущен,
         и обработал его - поскольку он не был обработан ранее.

    1.6 Удалим все ресурсы созданные контроллером
        kubectl delete mysqls.otus.homework mysql-instance
        kubectl delete deployments.apps mysql-instance
        kubectl delete pvc mysql-instance-pvc
        kubectl delete pv mysql-instance-pv
        kubectl delete svc mysql-instance

    1.7 Добавим код и запустим
        kopf run mysql-operator.py
        kubectl apply -f deploy/cr.yaml
        kubectl get pvc

    1.8 Заполним базу данных
        1.8.1 export MYSQLPOD=$(kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}")
        
        1.8.2 kubectl exec -it $MYSQLPOD -- mysql -u root -potuspassword -e "CREATE TABLE test ( id \
              smallint unsigned not null auto_increment, name varchar(20) not null, constraint \
              pk_example primary key (id) );" otus-database
        
        1.8.3 kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "INSERT INTO test ( id, name ) \
              VALUES ( null, 'some data' );" otus-database 
                      

        1.8.4 kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "INSERT INTO test ( id, name ) \
              VALUES ( null, 'some data-2' );" otus-database

    1.9 Посмотрим содержимое таблицы
        kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database


    1.10 Удалим 
        kubectl delete mysqls.otus.homework mysql-instance
        kubectl get pv
        kubectl get jobs.batch

    1.11 Создадим заново
        kubectl apply -f deploy/cr.yml
        kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
        kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
        export MYSQLPOD=$(kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}")
        kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database

        #kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
        mysql: [Warning] Using a password on the command line interface can be insecure.
        +----+-------------+
        | id | name        |
        +----+-------------+
        |  1 | some data   |
        |  2 | some data-2 |
        +----+-------------+



2 Создадим docker-контейнер
    2.1 Dockerfile 
        Dockerfile:
            FROM python:3.7
            COPY templates ./templates
            COPY mysql-operator.py ./mysql-operator.py
            RUN pip install kopf kubernetes pyyaml jinja2
            CMD kopf run /mysql-operator.py

    2.2 Отправлем в DockerHub
        docker build ./build/ --tag ustinsky/mysql-operator:v0.0.1
        docker images
        docker tag 07c37 ustinsky/mysql-operator:v0.0.1
        docker login
        docker push ustinsky/mysql-operator

    2.3 Скачаем 
        wget https://gist.githubusercontent.com/Evgenikk/581fa5bba6d924a3438be1e3d31aa468/raw/99429270c474cc434748e1058919e27df01d9a48/service-account.yml
        wget https://gist.githubusercontent.com/Evgenikk/581fa5bba6d924a3438be1e3d31aa468/raw/99429270c474cc434748e1058919e27df01d9a48/role.yml
        wget https://gist.githubusercontent.com/Evgenikk/581fa5bba6d924a3438be1e3d31aa468/raw/99429270c474cc434748e1058919e27df01d9a48/ClusterRoleBinding.yml
        wget https://gist.githubusercontent.com/Evgenikk/581fa5bba6d924a3438be1e3d31aa468/raw/619023d01e49ca3702357d4fded4d054cd523a9a/deploy-operator.yml

    2.4 Переустановим minikube
        minikube delete && minikube start

    2.5 Применим манифесты
        kubectl apply -f deploy/crd.yml
        kubectl apply -f service-account.yml
        kubectl apply -f role.yml
        kubectl apply -f ClusterRoleBinding.yml 
        kubectl apply -f deploy-operator.yml
        kubectl apply -f deploy/cr.yml

    2.6 Проверяем
        $ kubectl get pvc
        NAME                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
        backup-mysql-instance-pvc   Bound    pvc-5f06a495-0624-49d7-aac0-4682b2cfaba2   1Gi        RWO            standard       2m47s
        mysql-instance-pvc          Bound    pvc-bcad5009-d14c-4ef2-aad4-993d6e337313   1Gi        RWO            standard       2m48s

    2.7 Заполним базу данных
        2.7.1 export MYSQLPOD=$(kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}")
        
        2.7.2 kubectl exec -it $MYSQLPOD -- mysql -u root -potuspassword -e "CREATE TABLE test ( id \
              smallint unsigned not null auto_increment, name varchar(20) not null, constraint \
              pk_example primary key (id) );" otus-database
        
        2.7.3 kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "INSERT INTO test ( id, name ) \
              VALUES ( null, 'some data' );" otus-database 
                      

        2.7.4 kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "INSERT INTO test ( id, name ) \
              VALUES ( null, 'some data-2' );" otus-database

    2.8 Посмотрим содержимое таблицы
        kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database

    2.9 Удалим
        kubectl delete mysqls.otus.homework mysql-instance
        kubectl get pv
        kubectl get jobs.batch

    2.10 И создадим заново
        kubectl apply -f deploy/cr.yml
        export MYSQLPOD=$(kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}")
        kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database

        #kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
        mysql: [Warning] Using a password on the command line interface can be insecure.
        +----+-------------+
        | id | name        |
        +----+-------------+
        |  1 | some data   |
        |  2 | some data-2 |
        +----+-------------+

## Как запустить проект:
 -      kubectl apply -f deploy/crd.yml
        kubectl apply -f service-account.yml
        kubectl apply -f role.yml
        kubectl apply -f ClusterRoleBinding.yml 
        kubectl apply -f deploy-operator.yml
        kubectl apply -f deploy/cr.yml

-  Заполним базу данных
       export MYSQLPOD=$(kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}")
        
      kubectl exec -it $MYSQLPOD -- mysql -u root -potuspassword -e "CREATE TABLE test ( id \
              smallint unsigned not null auto_increment, name varchar(20) not null, constraint \
              pk_example primary key (id) );" otus-database
        
      kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "INSERT INTO test ( id, name ) \
              VALUES ( null, 'some data' );" otus-database 
                      

     kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "INSERT INTO test ( id, name ) \
              VALUES ( null, 'some data-2' );" otus-database

    

## Как проверить работоспособность:
 - Посмотрим содержимое таблицы
        kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
    +----+-------------+
     | id | name        |
    +----+-------------+
    |  1 | some data   |
    |  2 | some data-2 |
   +----+-------------+

## PR checklist:
 - [x] Выставлен label с номером домашнего задания